### PR TITLE
Update golang builder version

### DIFF
--- a/tutorials/deploy-hooks-run/app-config/hello-app/Dockerfile
+++ b/tutorials/deploy-hooks-run/app-config/hello-app/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 AS builder
+FROM golang:1.22 AS builder
 WORKDIR /go/src/hello
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hello

--- a/tutorials/deployment-strategies-run/app-config/demo-app/Dockerfile
+++ b/tutorials/deployment-strategies-run/app-config/demo-app/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 AS builder
+FROM golang:1.22 AS builder
 WORKDIR /go/src/demo
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/demo

--- a/tutorials/e2e-run/app-config/hello-app/Dockerfile
+++ b/tutorials/e2e-run/app-config/hello-app/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 AS builder
+FROM golang:1.22 AS builder
 WORKDIR /go/src/hello
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hello

--- a/tutorials/verification-run/app-config/hello-app/Dockerfile
+++ b/tutorials/verification-run/app-config/hello-app/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 AS builder
+FROM golang:1.22 AS builder
 WORKDIR /go/src/hello
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/hello


### PR DESCRIPTION
Backwards compatibility is maintained, so this updates the builder version only.