### PR TITLE
Updates for Cloud Build SA changes

### DIFF
--- a/tutorials/base/clouddeploy-config/skaffold.yaml.template
+++ b/tutorials/base/clouddeploy-config/skaffold.yaml.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta7
+apiVersion: skaffold/v3
 kind: Config
 build:
   artifacts:
@@ -22,11 +22,13 @@ build:
       context: leeroy-app
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-tut-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
+manifests:
+  rawYaml:
+    - leeroy-web/kubernetes/*
+    - leeroy-app/kubernetes/*
 deploy:
   kubectl:
-    manifests:
-      - leeroy-web/kubernetes/*
-      - leeroy-app/kubernetes/*
 portForward:
   - resourceType: deployment
     resourceName: leeroy-web

--- a/tutorials/base/setup.sh
+++ b/tutorials/base/setup.sh
@@ -35,12 +35,10 @@ manage_apis() {
     # Enables any APIs that we need prior to Terraform being run
 
     echo "Enabling GCP APIs, please wait, this may take several minutes..."
-    echo "Storage API"...
-    gcloud services enable storage.googleapis.com
-    echo "Compute API"...
-    gcloud services enable compute.googleapis.com
-    echo "Artifact Registry API"...
-    gcloud services enable artifactregistry.googleapis.com
+    gcloud services enable storage.googleapis.com \
+                           compute.googleapis.com \
+                           container.googleapis.com \
+                           artifactregistry.googleapis.com
 }
 
 manage_configs() {

--- a/tutorials/base/terraform-config/sa.tf
+++ b/tutorials/base/terraform-config/sa.tf
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+# Cloud Deploy service account
+
 resource "google_service_account" "deploy_service_account" {
   project      = var.project_id
   account_id   = "cd-tut-deploy-sa"
-  display_name = "Cloud Deploy Deployment Strategies tutorial deploy service account"
+  display_name = "Cloud Deploy tutorial deploy service account"
 }
 
-# Permissions for Cloud Deploy service account
 resource "google_project_iam_member" "deploy_sa_clouddeploy_jobrunner" {
   project = var.project_id
   role    = "roles/clouddeploy.jobRunner"
@@ -31,4 +32,30 @@ resource "google_project_iam_member" "deploy_sa_container_developer" {
   project = var.project_id
   role    = "roles/container.developer"
   member  = "serviceAccount:${google_service_account.deploy_service_account.email}"
+}
+
+# Cloud Build service account
+
+resource "google_service_account" "build_service_account" {
+  project      = var.project_id
+  account_id   = "cd-tut-build-sa"
+  display_name = "Cloud Deploy tutorial Cloud Build service account"
+}
+
+resource "google_project_iam_member" "build_sa_iam_storageadmin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_artifactwriter" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
 }

--- a/tutorials/deploy-hooks-run/app-config/skaffold.yaml.template
+++ b/tutorials/deploy-hooks-run/app-config/skaffold.yaml.template
@@ -22,6 +22,7 @@ build:
       context: hello-app
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-dh-tut-run-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
 manifests:
   rawYaml:
   - ./manifests/hello-app.yaml

--- a/tutorials/deploy-hooks-run/setup.sh
+++ b/tutorials/deploy-hooks-run/setup.sh
@@ -33,12 +33,9 @@ manage_apis() {
     # Enables any APIs that we need prior to Terraform being run
 
     echo "Enabling GCP APIs, please wait, this may take several minutes..."
-    echo "Storage API"...
-    gcloud services enable storage.googleapis.com
-    echo "Compute API"...
-    gcloud services enable compute.googleapis.com
-    echo "Artifact Registry API"...
-    gcloud services enable artifactregistry.googleapis.com
+    gcloud services enable storage.googleapis.com \
+                           compute.googleapis.com \
+                           artifactregistry.googleapis.com
 }
 
 manage_configs() {

--- a/tutorials/deploy-hooks-run/terraform-config/sa.tf
+++ b/tutorials/deploy-hooks-run/terraform-config/sa.tf
@@ -14,33 +14,40 @@
  * limitations under the License.
  */
 
+ # Cloud Build service account
+
+resource "google_service_account" "build_service_account" {
+  project      = var.project_id
+  account_id   = "cd-dh-tut-run-build-sa"
+  display_name = "Cloud Deploy Deploy Hooks tutorial Cloud Build service account"
+}
+
+resource "google_project_iam_member" "build_sa_iam_storageadmin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_artifactwriter" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+# Cloud Deploy service account
+
 resource "google_service_account" "compute_service_account" {
   project      = var.project_id
   account_id   = "cd-dh-tut-run-sa"
   display_name = "Cloud Deploy Deploy Hooks tutorial run service account"
 }
 
-resource "google_service_account" "deploy_service_account" {
-  project      = var.project_id
-  account_id   = "cd-dh-tut-deploy-sa"
-  display_name = "Cloud Deploy Deploy Hooks tutorial deploy service account"
-}
-
-# Permissions for Cloud Run (compute) service account
-resource "google_project_iam_member" "compute_sa_logginglogwriter" {
-  project = var.project_id
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
-}
-
-# Permissions for Cloud Deploy service account
-resource "google_project_iam_member" "deploy_sa_clouddeployjobrunner" {
-  project = var.project_id
-  role    = "roles/clouddeploy.jobRunner"
-  member  = "serviceAccount:${google_service_account.deploy_service_account.email}"
-}
-
-# Permissions for Cloud Deploy service account to insert data into BQ
 resource "google_project_iam_member" "deploy_sa_clouddeploybqeditor" {
   project = var.project_id
   role    = "roles/bigquery.dataEditor"
@@ -63,4 +70,24 @@ resource "google_service_account_iam_member" "deploy_sa_actas" {
   service_account_id = google_service_account.compute_service_account.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deploy_service_account.email}"
+}
+
+resource "google_project_iam_member" "deploy_sa_clouddeployjobrunner" {
+  project = var.project_id
+  role    = "roles/clouddeploy.jobRunner"
+  member  = "serviceAccount:${google_service_account.deploy_service_account.email}"
+}
+
+# Permissions for Cloud Run (compute) service account
+
+resource "google_service_account" "deploy_service_account" {
+  project      = var.project_id
+  account_id   = "cd-dh-tut-deploy-sa"
+  display_name = "Cloud Deploy Deploy Hooks tutorial deploy service account"
+}
+
+resource "google_project_iam_member" "compute_sa_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
 }

--- a/tutorials/deployment-strategies-run/app-config/skaffold.yaml.template
+++ b/tutorials/deployment-strategies-run/app-config/skaffold.yaml.template
@@ -22,6 +22,7 @@ build:
       context: demo-app
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-ds-tut-run-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
 manifests:
   kustomize:
     paths:

--- a/tutorials/deployment-strategies-run/setup.sh
+++ b/tutorials/deployment-strategies-run/setup.sh
@@ -33,12 +33,9 @@ manage_apis() {
     # Enables any APIs that we need prior to Terraform being run
 
     echo "Enabling GCP APIs, please wait, this may take several minutes..."
-    echo "Storage API"...
-    gcloud services enable storage.googleapis.com
-    echo "Compute API"...
-    gcloud services enable compute.googleapis.com
-    echo "Artifact Registry API"...
-    gcloud services enable artifactregistry.googleapis.com
+    gcloud services enable storage.googleapis.com \
+                           compute.googleapis.com \
+                           artifactregistry.googleapis.com
 }
 
 manage_configs() {

--- a/tutorials/deployment-strategies-run/terraform-config/sa.tf
+++ b/tutorials/deployment-strategies-run/terraform-config/sa.tf
@@ -14,11 +14,33 @@
  * limitations under the License.
  */
 
-resource "google_service_account" "compute_service_account" {
+ # Cloud Build service account
+
+resource "google_service_account" "build_service_account" {
   project      = var.project_id
-  account_id   = "cd-ds-tut-run-sa"
-  display_name = "Cloud Deploy Deployment Strategies tutorial run service account"
+  account_id   = "cd-ds-tut-run-build-sa"
+  display_name = "Cloud Deploy Deployment Strategies tutorial Cloud Build service account"
 }
+
+resource "google_project_iam_member" "build_sa_iam_storageadmin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_artifactwriter" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+# Cloud Deploy service account
 
 resource "google_service_account" "deploy_service_account" {
   project      = var.project_id
@@ -26,14 +48,6 @@ resource "google_service_account" "deploy_service_account" {
   display_name = "Cloud Deploy Deployment Strategies tutorial deploy service account"
 }
 
-# Permissions for Cloud Run (compute) service account
-resource "google_project_iam_member" "compute_sa_logginglogwriter" {
-  project = var.project_id
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
-}
-
-# Permissions for Cloud Deploy service account
 resource "google_project_iam_member" "deploy_sa_clouddeployjobrunner" {
   project = var.project_id
   role    = "roles/clouddeploy.jobRunner"
@@ -56,4 +70,18 @@ resource "google_service_account_iam_member" "deploy_sa_actas" {
   service_account_id = google_service_account.compute_service_account.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deploy_service_account.email}"
+}
+
+# Cloud Run service account
+
+resource "google_service_account" "compute_service_account" {
+  project      = var.project_id
+  account_id   = "cd-ds-tut-run-sa"
+  display_name = "Cloud Deploy Deployment Strategies tutorial run service account"
+}
+
+resource "google_project_iam_member" "compute_sa_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
 }

--- a/tutorials/e2e-run/app-config/skaffold.yaml.template
+++ b/tutorials/e2e-run/app-config/skaffold.yaml.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v3alpha1
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: hello-app
@@ -22,6 +22,7 @@ build:
       context: hello-app
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-tut-run-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
 deploy:
   cloudrun: {}
 profiles:

--- a/tutorials/e2e-run/setup.sh
+++ b/tutorials/e2e-run/setup.sh
@@ -33,12 +33,9 @@ manage_apis() {
     # Enables any APIs that we need prior to Terraform being run
 
     echo "Enabling GCP APIs, please wait, this may take several minutes..."
-    echo "Storage API"...
-    gcloud services enable storage.googleapis.com
-    echo "Compute API"...
-    gcloud services enable compute.googleapis.com
-    echo "Artifact Registry API"...
-    gcloud services enable artifactregistry.googleapis.com
+    gcloud services enable storage.googleapis.com \
+                           compute.googleapis.com \
+                           artifactregistry.googleapis.com
 }
 
 manage_configs() {

--- a/tutorials/e2e-run/terraform-config/sa.tf
+++ b/tutorials/e2e-run/terraform-config/sa.tf
@@ -14,26 +14,40 @@
  * limitations under the License.
  */
 
-resource "google_service_account" "compute_service_account" {
+# Cloud Build service account
+
+resource "google_service_account" "build_service_account" {
   project      = var.project_id
-  account_id   = "cd-tut-run-sa"
-  display_name = "Cloud Deploy Deployment Strategies tutorial run service account"
+  account_id   = "cd-tut-run-build-sa"
+  display_name = "Cloud Deploy tutorial Cloud Build service account"
 }
+
+resource "google_project_iam_member" "build_sa_iam_storageadmin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_artifactwriter" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+# Cloud Deploy service account
 
 resource "google_service_account" "deploy_service_account" {
   project      = var.project_id
   account_id   = "cd-tut-run-deploy-sa"
-  display_name = "Cloud Deploy Deployment Strategies tutorial deploy service account"
+  display_name = "Cloud Deploy tutorial deploy service account"
 }
 
-# Permissions for Cloud Run (compute) service account
-resource "google_project_iam_member" "compute_sa_logginglogwriter" {
-  project = var.project_id
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
-}
-
-# Permissions for Cloud Deploy service account
 resource "google_project_iam_member" "deploy_sa_clouddeployjobrunner" {
   project = var.project_id
   role    = "roles/clouddeploy.jobRunner"
@@ -50,4 +64,18 @@ resource "google_service_account_iam_member" "deploy_sa_actas" {
   service_account_id = google_service_account.compute_service_account.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deploy_service_account.email}"
+}
+
+# Cloud Run service account
+
+resource "google_service_account" "compute_service_account" {
+  project      = var.project_id
+  account_id   = "cd-tut-run-sa"
+  display_name = "Cloud Deploy Deployment Strategies tutorial run service account"
+}
+
+resource "google_project_iam_member" "compute_sa_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
 }

--- a/tutorials/exec-envs/clouddeploy-config/skaffold-exec-envs.yaml.template
+++ b/tutorials/exec-envs/clouddeploy-config/skaffold-exec-envs.yaml.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta7
+apiVersion: skaffold/v3
 kind: Config
 build:
   artifacts:
@@ -22,11 +22,13 @@ build:
       context: leeroy-app-exec-envs
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-tut-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
+manifests:
+  rawYaml:
+    - leeroy-web-exec-envs/kubernetes/*
+    - leeroy-app-exec-envs/kubernetes/*
 deploy:
   kubectl:
-    manifests:
-      - leeroy-web-exec-envs/kubernetes/*
-      - leeroy-app-exec-envs/kubernetes/*
 portForward:
   - resourceType: deployment
     resourceName: leeroy-web

--- a/tutorials/private-targets/clouddeploy-config/skaffold.yaml.template
+++ b/tutorials/private-targets/clouddeploy-config/skaffold.yaml.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta7
+apiVersion: skaffold/v3
 kind: Config
 build:
   artifacts:
@@ -22,11 +22,13 @@ build:
       context: leeroy-app
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-tut-private-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
+manifests:
+  rawYaml:
+    - leeroy-web/kubernetes/*
+    - leeroy-app/kubernetes/*
 deploy:
   kubectl:
-    manifests:
-      - leeroy-web/kubernetes/*
-      - leeroy-app/kubernetes/*
 portForward:
   - resourceType: deployment
     resourceName: leeroy-web

--- a/tutorials/private-targets/setup.sh
+++ b/tutorials/private-targets/setup.sh
@@ -35,12 +35,10 @@ manage_apis() {
     # Enables any APIs that we need prior to Terraform being run
 
     echo "Enabling GCP APIs, please wait, this may take several minutes..."
-    echo "Storage API"...
-    gcloud services enable storage.googleapis.com
-    echo "Compute API"...
-    gcloud services enable compute.googleapis.com
-    echo "Artifact Registry API"...
-    gcloud services enable artifactregistry.googleapis.com
+    gcloud services enable storage.googleapis.com \
+                           compute.googleapis.com \
+                           container.googleapis.com \
+                           artifactregistry.googleapis.com
 }
 
 manage_configs() {

--- a/tutorials/private-targets/terraform-config/sa.tf
+++ b/tutorials/private-targets/terraform-config/sa.tf
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+ # Cloud Deploy service account
+
 resource "google_service_account" "deploy_service_account" {
   project      = var.project_id
   account_id   = "cd-tut-private-deploy-sa"
-  display_name = "Cloud Deploy Deployment Strategies tutorial deploy service account"
+  display_name = "Cloud Deploy tutorial deploy service account"
 }
 
 resource "google_project_iam_member" "jobrunner_binding" {
@@ -30,4 +32,30 @@ resource "google_project_iam_member" "developer_binding" {
   project = var.project_id
   role    = "roles/container.developer"
   member  = "serviceAccount:${google_service_account.deploy_service_account.email}"
+}
+
+# Cloud Build service account
+
+resource "google_service_account" "build_service_account" {
+  project      = var.project_id
+  account_id   = "cd-tut-private-build-sa"
+  display_name = "Cloud Deploy tutorial Cloud Build service account"
+}
+
+resource "google_project_iam_member" "build_sa_iam_storageadmin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_artifactwriter" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
 }

--- a/tutorials/profiles/clouddeploy-config/skaffold-profiles.yaml.template
+++ b/tutorials/profiles/clouddeploy-config/skaffold-profiles.yaml.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta7
+apiVersion: skaffold/v3
 kind: Config
 build:
   artifacts:
@@ -22,23 +22,25 @@ build:
       context: leeroy-app-profiles
   googleCloudBuild:
     projectId: ${PROJECT_ID}
-deploy:
-  kubectl:
-    manifests:
-      - leeroy-web-profiles/kubernetes/*
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-tut-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
+manifests:
+  rawYaml:
+    - leeroy-web-profiles/kubernetes/*
 profiles:
 - name: test
-  deploy:
+  manifests:
     kustomize:
       paths:
         - leeroy-app-profiles/kubernetes/test
 - name: staging
-  deploy:
+  manifests:
     kustomize:
       paths:
         - leeroy-app-profiles/kubernetes/staging
 - name: prod
-  deploy:
+  manifests:
     kustomize:
       paths:
         - leeroy-app-profiles/kubernetes/prod
+deploy:
+  kubectl:

--- a/tutorials/verification-run/app-config/skaffold.yaml.template
+++ b/tutorials/verification-run/app-config/skaffold.yaml.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v3alpha1
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: hello-app
@@ -24,6 +24,7 @@ build:
       context: hello-verify
   googleCloudBuild:
     projectId: ${PROJECT_ID}
+    serviceAccount: projects/${PROJECT_ID}/serviceAccounts/cd-dv-tut-run-build-sa@${PROJECT_ID}.iam.gserviceaccount.com
 deploy:
   cloudrun: {}
 profiles:

--- a/tutorials/verification-run/setup.sh
+++ b/tutorials/verification-run/setup.sh
@@ -33,12 +33,9 @@ manage_apis() {
     # Enables any APIs that we need prior to Terraform being run
 
     echo "Enabling GCP APIs, please wait, this may take several minutes..."
-    echo "Storage API"...
-    gcloud services enable storage.googleapis.com
-    echo "Compute API"...
-    gcloud services enable compute.googleapis.com
-    echo "Artifact Registry API"...
-    gcloud services enable artifactregistry.googleapis.com
+    gcloud services enable storage.googleapis.com \
+                           compute.googleapis.com \
+                           artifactregistry.googleapis.com
 }
 
 manage_configs() {

--- a/tutorials/verification-run/terraform-config/sa.tf
+++ b/tutorials/verification-run/terraform-config/sa.tf
@@ -14,11 +14,33 @@
  * limitations under the License.
  */
 
-resource "google_service_account" "compute_service_account" {
+ # Cloud Build service account
+
+resource "google_service_account" "build_service_account" {
   project      = var.project_id
-  account_id   = "cd-dv-tut-run-sa"
-  display_name = "Cloud Deploy Deployment Verification tutorial run service account"
+  account_id   = "cd-dv-tut-run-build-sa"
+  display_name = "Cloud Deploy Deployment Verification tutorial Cloud Build service account"
 }
+
+resource "google_project_iam_member" "build_sa_iam_storageadmin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+resource "google_project_iam_member" "build_sa_iam_artifactwriter" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.build_service_account.email}"
+}
+
+# Cloud Deploy service account
 
 resource "google_service_account" "service_account" {
   project      = var.project_id
@@ -72,4 +94,18 @@ resource "google_service_account_iam_member" "sa_account_compute_user" {
   service_account_id = google_service_account.compute_service_account.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+# Cloud Run service account
+
+resource "google_service_account" "compute_service_account" {
+  project      = var.project_id
+  account_id   = "cd-dv-tut-run-sa"
+  display_name = "Cloud Deploy Deployment Verification tutorial run service account"
+}
+
+resource "google_project_iam_member" "compute_sa_logginglogwriter" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.compute_service_account.email}"
 }


### PR DESCRIPTION
This updates the tutorial examples to use a custom service account for all Cloud Build jobs. Details:

https://cloud.google.com/build/docs/cloud-build-service-account-updates